### PR TITLE
vim4 metrology update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@
 ext.title = "FireSat Example"
 description='The FireSat example project'
 group = 'io.opencaesar.ontologies'
-version = '3.0.0'
+version = '3.1.0'
 
 apply from: "${rootDir}/gradle/maven-deployment.gradle"
 

--- a/src/oml/opencaesar.io/examples/firesat/disciplines/fse/fse.oml
+++ b/src/oml/opencaesar.io/examples/firesat/disciplines/fse/fse.oml
@@ -11,17 +11,15 @@ vocabulary <http://opencaesar.io/examples/firesat/disciplines/fse/fse#> as fse {
 
 	extends <http://imce.jpl.nasa.gov/foundation/project#> as project
 
-	extends <http://iupac.org/metrology#> as metrology
+	extends <http://bipm.org/jcgm/vim4#> as vim4
 
-	extends <http://iso.org/iso-80000-4-quantities#> as iso-80000-4-quantities
-
-	extends <http://iso.org/iso-80000-4-magnitudes-1#> as iso-80000-4-magnitudes-1
+	uses <http://iso.org/iso-80000-4.1#> as iso-80000-4.1
 
 	// The terms
 
 	aspect EndCircuitPresentingElement :> mission:PresentingElement
 
-	aspect MassConstrainedElement :> metrology:Object
+	aspect MassConstrainedElement :> vim4:Object
 
 	ref concept project:WorkPackage :> MassConstrainedElement
 
@@ -54,8 +52,10 @@ vocabulary <http://opencaesar.io/examples/firesat/disciplines/fse/fse#> as fse {
 		
 	]
 
-	concept MassConstraint :> iso-80000-4-quantities:mass, iso-80000-4-magnitudes-1:kilogram-magnitude [
-		restricts all relation metrology:isQuantityOf to MassConstrainedElement
+	concept MassConstraint :> vim4:InherentUnitaryQuantityValue [
+		restricts all relation vim4:characterizes to MassConstrainedElement
+    restricts relation vim4:instantiates to iso-80000-4.1:mass
+    restricts relation vim4:unit to iso-80000-4.1:kilogram
 	]
 
 	concept MassAllocationConstraint :> MassConstraint

--- a/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/systems/pld/masses.oml
+++ b/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/systems/pld/masses.oml
@@ -7,7 +7,7 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 
 	uses <http://www.w3.org/2001/XMLSchema#> as xsd
 
-	uses <http://iupac.org/metrology#> as metrology
+	uses <http://bipm.org/jcgm/vim4#> as vim4
 
 	uses <http://opencaesar.io/examples/firesat/disciplines/fse/fse#> as fse
 
@@ -17,7 +17,8 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 	
 	@rdfs:label "Payload Mass Limit Constraint"
 	ci PayloadMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "28.1"^^xsd:double
-		metrology:isQuantityOf pld:Payload
+    vim4:hasDoubleNumber "28.1"^^xsd:double
+		vim4:characterizes pld:Payload
 	]
+	
 }

--- a/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/systems/spc/masses.oml
+++ b/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/systems/spc/masses.oml
@@ -7,7 +7,7 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 
 	uses <http://www.w3.org/2001/XMLSchema#> as xsd
 
-	uses <http://iupac.org/metrology#> as metrology
+  uses <http://bipm.org/jcgm/vim4#> as vim4
 
 	uses <http://opencaesar.io/examples/firesat/disciplines/fse/fse#> as fse
 
@@ -17,8 +17,7 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 
 	@rdfs:label "Spacecraft Mass Limit Constraint"
 	ci PayloadMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "235.1"^^xsd:double
-		metrology:isQuantityOf spc:Spacecraft
+    vim4:hasDoubleNumber "235.1"^^xsd:double
+		vim4:characterizes spc:Spacecraft
 	]
-
 }

--- a/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/workpackages/05/systems/pld/masses.oml
+++ b/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/workpackages/05/systems/pld/masses.oml
@@ -7,7 +7,7 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 
 	uses <http://www.w3.org/2000/01/rdf-schema#> as rdfs
 
-	uses <http://iupac.org/metrology#> as metrology
+  uses <http://bipm.org/jcgm/vim4#> as vim4
 
 	uses <http://opencaesar.io/examples/firesat/disciplines/fse/fse#> as fse
 
@@ -17,16 +17,16 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 
 	@rdfs:label "Payload Module Mass Limit Constraint"
 	ci PayloadModuleMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.6"^^xsd:double
-		metrology:isQuantityOf pld-assemblies:PayloadModule
+    vim4:hasDoubleNumber "0.6"^^xsd:double
+		vim4:characterizes pld-assemblies:PayloadModule
 	]
-
+	
 	// Sensor Mass
 
 	@rdfs:label "Sensor Mass Limit Constraint"
 	ci SensorMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "28.1"^^xsd:double
-		metrology:isQuantityOf pld-assemblies:Sensor
+    vim4:hasDoubleNumber "28.1"^^xsd:double
+		vim4:isAttributedTo pld-assemblies:Sensor
 	]
 	
 }

--- a/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/workpackages/05/systems/pld/masses.oml
+++ b/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/workpackages/05/systems/pld/masses.oml
@@ -26,7 +26,7 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 	@rdfs:label "Sensor Mass Limit Constraint"
 	ci SensorMassLimitConstraint : fse:MassLimitConstraint [
     vim4:hasDoubleNumber "28.1"^^xsd:double
-		vim4:isAttributedTo pld-assemblies:Sensor
+		vim4:characterizes pld-assemblies:Sensor
 	]
 	
 }

--- a/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/workpackages/06/04/subsystems/sam/masses.oml
+++ b/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/workpackages/06/04/subsystems/sam/masses.oml
@@ -7,7 +7,7 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 
 	uses <http://www.w3.org/2000/01/rdf-schema#> as rdfs
 
-	uses <http://iupac.org/metrology#> as metrology
+	uses <http://bipm.org/jcgm/vim4#> as vim4
 
 	uses <http://opencaesar.io/examples/firesat/disciplines/fse/fse#> as fse
 
@@ -17,32 +17,32 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 
 	@rdfs:label "Power Control Unit Mass Limit Constraint"
 	ci PowerControlUnitMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "5.96"^^xsd:double
-		metrology:isQuantityOf sam-assemblies:PowerControlUnit
+		vim4:hasDoubleNumber "5.96"^^xsd:double
+		vim4:characterizes sam-assemblies:PowerControlUnit
 	]
 
 	// EPS Regulators And Converters Unit Mass
 
 	@rdfs:label "EPS Regulators and Converters Unit Mass Limit Constraint"
 	ci EPSRegulatorsAndConvertersUnitMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "14.48"^^xsd:double
-		metrology:isQuantityOf sam-assemblies:EPSRegulatorsAndConvertersUnit
+		vim4:hasDoubleNumber "14.48"^^xsd:double
+		vim4:characterizes sam-assemblies:EPSRegulatorsAndConvertersUnit
 	]
 
 	// Solar Array With SADA 1 Mass
 
 	@rdfs:label "Solar Array With SADA 1 Mass Limit Constraint"
 	ci SolarArrayWithSADA1MassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "7.965"^^xsd:double
-		metrology:isQuantityOf sam-assemblies:SolarArrayWithSADA1
+		vim4:hasDoubleNumber "7.965"^^xsd:double
+		vim4:characterizes sam-assemblies:SolarArrayWithSADA1
 	]
 
 	// Solar Array With SADA 2 Mass
 
 	@rdfs:label "Solar Array With SADA 2 Mass Limit Constraint"
 	ci SolarArrayWithSADA2MassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "7.965"^^xsd:double
-		metrology:isQuantityOf sam-assemblies:SolarArrayWithSADA2
+		vim4:hasDoubleNumber "7.965"^^xsd:double
+		vim4:characterizes sam-assemblies:SolarArrayWithSADA2
 	]
 
 }

--- a/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/workpackages/06/05/subsystems/thc/masses.oml
+++ b/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/workpackages/06/05/subsystems/thc/masses.oml
@@ -7,7 +7,7 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 
 	uses <http://www.w3.org/2000/01/rdf-schema#> as rdfs
 
-	uses <http://iupac.org/metrology#> as metrology
+  uses <http://bipm.org/jcgm/vim4#> as vim4
 
 	uses <http://opencaesar.io/examples/firesat/disciplines/fse/fse#> as fse
 
@@ -17,8 +17,8 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 
 	@rdfs:label "Thermal Blankets Mass Limit Constraint"
 	ci ThermalBlanketsMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "3.9"^^xsd:double
-		metrology:isQuantityOf thc-assemblies:ThermalBlankets
+		vim4:hasDoubleNumber "3.9"^^xsd:double
+		vim4:characterizes thc-assemblies:ThermalBlankets
 	]
 
 }

--- a/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/workpackages/06/06/subsystems/eps/masses.oml
+++ b/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/workpackages/06/06/subsystems/eps/masses.oml
@@ -7,7 +7,7 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 
 	uses <http://www.w3.org/2000/01/rdf-schema#> as rdfs
 
-	uses <http://iupac.org/metrology#> as metrology
+	uses <http://bipm.org/jcgm/vim4#> as vim4
 
 	uses <http://opencaesar.io/examples/firesat/disciplines/fse/fse#> as fse
 
@@ -17,24 +17,24 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 
 	@rdfs:label "Battery Pack 1 Mass Limit Constraint"
 	ci BatteryPack1MassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "3.103"^^xsd:double
-		metrology:isQuantityOf eps-assemblies:BatteryPack1
+		vim4:hasDoubleNumber "3.103"^^xsd:double
+		vim4:characterizes eps-assemblies:BatteryPack1
 	]
 
 	// Battery Pack 2 Mass
 
 	@rdfs:label "Battery Pack 2 Mass Limit Constraint"
 	ci BatteryPack2MassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "3.103"^^xsd:double
-		metrology:isQuantityOf eps-assemblies:BatteryPack2
+		vim4:hasDoubleNumber "3.103"^^xsd:double
+		vim4:characterizes eps-assemblies:BatteryPack2
 	]
 
 	// Battery Pack 3 Mass
 
 	@rdfs:label "Thermal Blankets Mass Limit Constraint"
 	ci BatteryPack3MassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "3.103"^^xsd:double
-		metrology:isQuantityOf eps-assemblies:BatteryPack3
+		vim4:hasDoubleNumber "3.103"^^xsd:double
+		vim4:characterizes eps-assemblies:BatteryPack3
 	]
 
 }

--- a/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/workpackages/06/07/subsystems/ang/masses.oml
+++ b/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/workpackages/06/07/subsystems/ang/masses.oml
@@ -7,7 +7,7 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 
 	uses <http://www.w3.org/2000/01/rdf-schema#> as rdfs
 
-	uses <http://iupac.org/metrology#> as metrology
+	uses <http://bipm.org/jcgm/vim4#> as vim4
 
 	uses <http://opencaesar.io/examples/firesat/disciplines/fse/fse#> as fse
 
@@ -17,104 +17,104 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 
 	@rdfs:label "Magnetometer Mass Limit Constraint"
 	ci MagnetometerMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.85"^^xsd:double
-		metrology:isQuantityOf ang-assemblies:Magnetometer
+		vim4:hasDoubleNumber "0.85"^^xsd:double
+		vim4:characterizes ang-assemblies:Magnetometer
 	]
 
 	// GPS Antenna Mass
 
 	@rdfs:label "GPS Antenna Mass Limit Constraint"
 	ci GPSAntennaMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.25"^^xsd:double
-		metrology:isQuantityOf ang-assemblies:GPSAntenna
+		vim4:hasDoubleNumber "0.25"^^xsd:double
+		vim4:characterizes ang-assemblies:GPSAntenna
 	]
 
 	// GPS Receiver Unit Mass
 
 	@rdfs:label "GPS Receiver Unit Mass Limit Constraint"
 	ci GPSReceiverUnitMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "1.0"^^xsd:double
-		metrology:isQuantityOf ang-assemblies:GPSReceiverUnit
+		vim4:hasDoubleNumber "1.0"^^xsd:double
+		vim4:characterizes ang-assemblies:GPSReceiverUnit
 	]
 
 	// ADCS Electronics Unit Mass
 
 	@rdfs:label "ADCS Electronics Unit Mass Limit Constraint"
 	ci ADCSElectronicsUnitMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "2.0"^^xsd:double
-		metrology:isQuantityOf ang-assemblies:ADCSElectronicsUnit
+		vim4:hasDoubleNumber "2.0"^^xsd:double
+		vim4:characterizes ang-assemblies:ADCSElectronicsUnit
 	]
 
 	// Sun Sensor Mass
 
 	@rdfs:label "Sun Sensor Mass Limit Constraint"
 	ci SunSensorMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.6"^^xsd:double
-		metrology:isQuantityOf ang-assemblies:SunSensor
+		vim4:hasDoubleNumber "0.6"^^xsd:double
+		vim4:characterizes ang-assemblies:SunSensor
 	]
 
 	// Earth Sensor Mass
 
 	@rdfs:label "Earth Sensor Mass Limit Constraint"
 	ci EarthSensorMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "2.75"^^xsd:double
-		metrology:isQuantityOf ang-assemblies:EarthSensor
+		vim4:hasDoubleNumber "2.75"^^xsd:double
+		vim4:characterizes ang-assemblies:EarthSensor
 	]
 
 	// Reaction Wheel 1 Mass
 
 	@rdfs:label "Reaction Wheel 1 Mass Limit Constraint"
 	ci ReactionWheel1MassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.1975"^^xsd:double
-		metrology:isQuantityOf ang-assemblies:ReactionWheel1
+		vim4:hasDoubleNumber "0.1975"^^xsd:double
+		vim4:characterizes ang-assemblies:ReactionWheel1
 	]
 
 	// Reaction Wheel 2 Mass
 
 	@rdfs:label "Reaction Wheel 2 Mass Limit Constraint"
 	ci ReactionWheel2MassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.1975"^^xsd:double
-		metrology:isQuantityOf ang-assemblies:ReactionWheel2
+		vim4:hasDoubleNumber "0.1975"^^xsd:double
+		vim4:characterizes ang-assemblies:ReactionWheel2
 	]
 
 	// Reaction Wheel 3 Mass
 
 	@rdfs:label "Reaction Wheel 3 Mass Limit Constraint"
 	ci ReactionWheel3MassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.1975"^^xsd:double
-		metrology:isQuantityOf ang-assemblies:ReactionWheel3
+		vim4:hasDoubleNumber "0.1975"^^xsd:double
+		vim4:characterizes ang-assemblies:ReactionWheel3
 	]
 
 	// Reaction Wheel 4 Mass
 
 	@rdfs:label "Reaction Wheel 4 Mass Limit Constraint"
 	ci ReactionWheel4MassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.1975"^^xsd:double
-		metrology:isQuantityOf ang-assemblies:ReactionWheel4
+		vim4:hasDoubleNumber "0.1975"^^xsd:double
+		vim4:characterizes ang-assemblies:ReactionWheel4
 	]
 
 	// Magnetorquer 1 Mass
 
 	@rdfs:label "Magnetorquer 1 Mass Limit Constraint"
 	ci Magnetorquer1MassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.5"^^xsd:double
-		metrology:isQuantityOf ang-assemblies:Magnetorquer1
+		vim4:hasDoubleNumber "0.5"^^xsd:double
+		vim4:characterizes ang-assemblies:Magnetorquer1
 	]
 
 	// Magnetorquer 2 Mass
 
 	@rdfs:label "Magnetorquer Mass Limit Constraint"
 	ci Magnetorquer2MassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.5"^^xsd:double
-		metrology:isQuantityOf ang-assemblies:Magnetorquer2
+		vim4:hasDoubleNumber "0.5"^^xsd:double
+		vim4:characterizes ang-assemblies:Magnetorquer2
 	]
 
 	// Magnetorquer 3 Mass
 
 	@rdfs:label "Magnetorquer 3 Mass Limit Constraint"
 	ci Magnetorquer3MassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.5"^^xsd:double
-		metrology:isQuantityOf ang-assemblies:Magnetorquer3
+		vim4:hasDoubleNumber "0.5"^^xsd:double
+		vim4:characterizes ang-assemblies:Magnetorquer3
 	]
 
 }

--- a/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/workpackages/06/08/subsystems/prp/masses.oml
+++ b/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/workpackages/06/08/subsystems/prp/masses.oml
@@ -7,7 +7,7 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 
 	uses <http://www.w3.org/2000/01/rdf-schema#> as rdfs
 
-	uses <http://iupac.org/metrology#> as metrology
+	uses <http://bipm.org/jcgm/vim4#> as vim4
 
 	uses <http://opencaesar.io/examples/firesat/disciplines/fse/fse#> as fse
 
@@ -17,120 +17,120 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 
 	@rdfs:label "Propulsion System Control Unit Mass Limit Constraint"
 	ci PropulsionSystemControlUnitMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "1.0"^^xsd:double
-		metrology:isQuantityOf prp-assemblies:PropulsionSystemControlUnit
+		vim4:hasDoubleNumber "1.0"^^xsd:double
+		vim4:characterizes prp-assemblies:PropulsionSystemControlUnit
 	]
 
 	// Primary Thruster Mass
 
 	@rdfs:label "Primary Thruster Mass Limit Constraint"
 	ci PrimaryThrusterMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "1.0"^^xsd:double
-		metrology:isQuantityOf prp-assemblies:PrimaryThruster
+		vim4:hasDoubleNumber "1.0"^^xsd:double
+		vim4:characterizes prp-assemblies:PrimaryThruster
 	]
 
 	// ACS Thruster 1 Mass
 
 	@rdfs:label "A CS Thruster 1  Mass Limit Constraint"
 	ci ACSThruster1MassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.5"^^xsd:double
-		metrology:isQuantityOf prp-assemblies:ACSThruster1
+		vim4:hasDoubleNumber "0.5"^^xsd:double
+		vim4:characterizes prp-assemblies:ACSThruster1
 	]
 
 	// ACS Thruster 2 Mass
 
 	@rdfs:label "A CS Thruster 2 Mass Limit Constraint"
 	ci ACSThruster2MassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.5"^^xsd:double
-		metrology:isQuantityOf prp-assemblies:ACSThruster2
+		vim4:hasDoubleNumber "0.5"^^xsd:double
+		vim4:characterizes prp-assemblies:ACSThruster2
 	]
 
 	// ACS Thruster 3 Mass
 
 	@rdfs:label "A CS Thruster 3 Mass Limit Constraint"
 	ci ACSThruster3MassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.5"^^xsd:double
-		metrology:isQuantityOf prp-assemblies:ACSThruster3
+		vim4:hasDoubleNumber "0.5"^^xsd:double
+		vim4:characterizes prp-assemblies:ACSThruster3
 	]
 
 	// ACS Thruster 4 Mass
 
 	@rdfs:label "A CS Thruster 4 Mass Limit Constraint"
 	ci ACSThruster4MassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.5"^^xsd:double
-		metrology:isQuantityOf prp-assemblies:ACSThruster4
+		vim4:hasDoubleNumber "0.5"^^xsd:double
+		vim4:characterizes prp-assemblies:ACSThruster4
 	]
 
 	// ACS Thruster 5 Mass
 
 	@rdfs:label "A CS Thruster 5 Mass Limit Constraint"
 	ci ACSThruster5MassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.5"^^xsd:double
-		metrology:isQuantityOf prp-assemblies:ACSThruster5
+		vim4:hasDoubleNumber "0.5"^^xsd:double
+		vim4:characterizes prp-assemblies:ACSThruster5
 	]
 
 	// ACS Thruster 6 Mass
 
 	@rdfs:label "A CS Thruster 6 Mass Limit Constraint"
 	ci ACSThruster6MassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.5"^^xsd:double
-		metrology:isQuantityOf prp-assemblies:ACSThruster6
+		vim4:hasDoubleNumber "0.5"^^xsd:double
+		vim4:characterizes prp-assemblies:ACSThruster6
 	]
 
 	// Propellant Handling Section Mass
 
 	@rdfs:label "Propellant Handling Section Mass Limit Constraint"
 	ci PropellantHandlingSectionMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.6"^^xsd:double
-		metrology:isQuantityOf prp-assemblies:PropellantHandlingSection
+		vim4:hasDoubleNumber "0.6"^^xsd:double
+		vim4:characterizes prp-assemblies:PropellantHandlingSection
 	]
 
 	// Fill Drain Valve Unit Mass
 
 	@rdfs:label "Fill Drain Valve Unit Mass Limit Constraint"
 	ci FillDrainValveUnitMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "3.75"^^xsd:double
-		metrology:isQuantityOf prp-assemblies:FillDrainValveUnit
+		vim4:hasDoubleNumber "3.75"^^xsd:double
+		vim4:characterizes prp-assemblies:FillDrainValveUnit
 	]
 
 	// BP Propellant Line Unit Mass
 
 	@rdfs:label "BP Propellant Line Unit Mass Limit Constraint"
 	ci BPPropellantLineUnitMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "2.695"^^xsd:double
-		metrology:isQuantityOf prp-assemblies:BPPropellantLineUnit
+		vim4:hasDoubleNumber "2.695"^^xsd:double
+		vim4:characterizes prp-assemblies:BPPropellantLineUnit
 	]
 
 	// Propulsion Module Mass
 
 	@rdfs:label "Propulsion Module Mass Limit Constraint"
 	ci PropulsionModuleMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.6"^^xsd:double
-		metrology:isQuantityOf prp-assemblies:PropulsionModule
+		vim4:hasDoubleNumber "0.6"^^xsd:double
+		vim4:characterizes prp-assemblies:PropulsionModule
 	]
 
 	// Propellant Tank Mass
 
 	@rdfs:label "Propellant Tank Mass Limit Constraint"
 	ci PropellantTankMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "20.0"^^xsd:double
-		metrology:isQuantityOf prp-assemblies:PropellantTank
+		vim4:hasDoubleNumber "20.0"^^xsd:double
+		vim4:characterizes prp-assemblies:PropellantTank
 	]
 
 	// Pressurant Tank Mass
 
 	@rdfs:label "Pressurant Tank Mass Limit Constraint"
 	ci PressurantTankMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "10.0"^^xsd:double
-		metrology:isQuantityOf prp-assemblies:PressurantTank
+		vim4:hasDoubleNumber "10.0"^^xsd:double
+		vim4:characterizes prp-assemblies:PressurantTank
 	]
 
 	// PM Propellant Line Unit Mass
 
 	@rdfs:label "PM Propellant Line Unit Mass Limit Constraint"
 	ci PMPropellantLineUnitMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "2.695"^^xsd:double
-		metrology:isQuantityOf prp-assemblies:PMPropellantLineUnit
+		vim4:hasDoubleNumber "2.695"^^xsd:double
+		vim4:characterizes prp-assemblies:PMPropellantLineUnit
 	]
 
 }

--- a/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/workpackages/06/09/subsystems/cmn/masses.oml
+++ b/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/workpackages/06/09/subsystems/cmn/masses.oml
@@ -7,7 +7,7 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 
 	uses <http://www.w3.org/2000/01/rdf-schema#> as rdfs
 
-	uses <http://iupac.org/metrology#> as metrology
+	uses <http://bipm.org/jcgm/vim4#> as vim4
 
 	uses <http://opencaesar.io/examples/firesat/disciplines/fse/fse#> as fse
 
@@ -17,40 +17,40 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 
 	@rdfs:label "Transmitter Unit Unit Mass Limit Constraint"
 	ci TransmitterUnitMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "2.1"^^xsd:double
-		metrology:isQuantityOf cmn-assemblies:TransmitterUnit
+		vim4:hasDoubleNumber "2.1"^^xsd:double
+		vim4:characterizes cmn-assemblies:TransmitterUnit
 	]
 
 	// Receiver Unit Mass
 
 	@rdfs:label "Receiver Unit Mass Limit Constraint"
 	ci ReceiverUnitMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "1.0"^^xsd:double
-		metrology:isQuantityOf cmn-assemblies:ReceiverUnit
+		vim4:hasDoubleNumber "1.0"^^xsd:double
+		vim4:characterizes cmn-assemblies:ReceiverUnit
 	]
 
 	// Transmit Whip Antenna Mass
 
 	@rdfs:label "Transmit Whip Antenna Mass Limit Constraint"
 	ci TransmitWhipAntennaMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.04"^^xsd:double
-		metrology:isQuantityOf cmn-assemblies:TransmitWhipAntenna
+		vim4:hasDoubleNumber "0.04"^^xsd:double
+		vim4:characterizes cmn-assemblies:TransmitWhipAntenna
 	]
 
 	// Transmit Hi-Gain Antenna Mass
 
 	@rdfs:label "Transmit Hi-Gain Antenna Mass Limit Constraint"
 	ci TransmitHiGainAntennaMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.04"^^xsd:double
-		metrology:isQuantityOf cmn-assemblies:TransmitHiGainAntenna
+		vim4:hasDoubleNumber "0.04"^^xsd:double
+		vim4:characterizes cmn-assemblies:TransmitHiGainAntenna
 	]
 
 	// Receive Whip Antenna Mass
 
 	@rdfs:label "Receive Whip Antenna Mass Limit Constraint"
 	ci ReceiveWhipAntennaMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.08"^^xsd:double
-		metrology:isQuantityOf cmn-assemblies:ReceiveWhipAntenna
+		vim4:hasDoubleNumber "0.08"^^xsd:double
+		vim4:characterizes cmn-assemblies:ReceiveWhipAntenna
 	]
 
 }

--- a/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/workpackages/06/10/subsystems/cdh/masses.oml
+++ b/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/workpackages/06/10/subsystems/cdh/masses.oml
@@ -7,7 +7,7 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 
 	uses <http://www.w3.org/2000/01/rdf-schema#> as rdfs
 
-	uses <http://iupac.org/metrology#> as metrology
+	uses <http://bipm.org/jcgm/vim4#> as vim4
 
 	uses <http://opencaesar.io/examples/firesat/disciplines/fse/fse#> as fse
 
@@ -17,224 +17,224 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 
 	@rdfs:label "Propulsion Structure Post 1 Mass Limit Constraint"
 	ci PropulsionStructurePost1MassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.6"^^xsd:double
-		metrology:isQuantityOf cdh-assemblies:PropulsionStructurePost1
+		vim4:hasDoubleNumber "0.6"^^xsd:double
+		vim4:characterizes cdh-assemblies:PropulsionStructurePost1
 	]
 
 	// Propulsion Structure Post 2 Mass
 
 	@rdfs:label "Propulsion Structure Post 2 Mass Limit Constraint"
 	ci PropulsionStructurePost2MassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.6"^^xsd:double
-		metrology:isQuantityOf cdh-assemblies:PropulsionStructurePost2
+		vim4:hasDoubleNumber "0.6"^^xsd:double
+		vim4:characterizes cdh-assemblies:PropulsionStructurePost2
 	]
 
 	// Propulsion Structure Post 3 Mass
 
 	@rdfs:label "Propulsion Structure Post 3 Mass Limit Constraint"
 	ci PropulsionStructurePost3MassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.6"^^xsd:double
-		metrology:isQuantityOf cdh-assemblies:PropulsionStructurePost3
+		vim4:hasDoubleNumber "0.6"^^xsd:double
+		vim4:characterizes cdh-assemblies:PropulsionStructurePost3
 	]
 
 	// Propulsion Structure Post 4 Mass
 
 	@rdfs:label "Propulsion Structure Post 4 Mass Limit Constraint"
 	ci PropulsionStructurePost4MassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.6"^^xsd:double
-		metrology:isQuantityOf cdh-assemblies:PropulsionStructurePost4
+		vim4:hasDoubleNumber "0.6"^^xsd:double
+		vim4:characterizes cdh-assemblies:PropulsionStructurePost4
 	]
 
 	// Structure Post 1 Mass
 
 	@rdfs:label "Structure Post 1 Mass Limit Constraint"
 	ci StructurePost1MassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.6"^^xsd:double
-		metrology:isQuantityOf cdh-assemblies:StructurePost1
+		vim4:hasDoubleNumber "0.6"^^xsd:double
+		vim4:characterizes cdh-assemblies:StructurePost1
 	]
 
 	// Structure Post 2 Mass
 
 	@rdfs:label "Structure Post 2 Mass Limit Constraint"
 	ci StructurePost2MassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.6"^^xsd:double
-		metrology:isQuantityOf cdh-assemblies:StructurePost2
+		vim4:hasDoubleNumber "0.6"^^xsd:double
+		vim4:characterizes cdh-assemblies:StructurePost2
 	]
 
 	// Structure Post 3 Mass
 
 	@rdfs:label "Structure Post 3 Mass Limit Constraint"
 	ci StructurePost3MassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.6"^^xsd:double
-		metrology:isQuantityOf cdh-assemblies:StructurePost3
+		vim4:hasDoubleNumber "0.6"^^xsd:double
+		vim4:characterizes cdh-assemblies:StructurePost3
 	]
 
 	// Structure Post 4 Mass
 
 	@rdfs:label "Structure Post 4 Mass Limit Constraint"
 	ci StructurePost4MassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.6"^^xsd:double
-		metrology:isQuantityOf cdh-assemblies:StructurePost4
+		vim4:hasDoubleNumber "0.6"^^xsd:double
+		vim4:characterizes cdh-assemblies:StructurePost4
 	]
 
 	// Structure Post 5 Mass
 
 	@rdfs:label "Structure Post 5 Mass Limit Constraint"
 	ci StructurePost5MassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.6"^^xsd:double
-		metrology:isQuantityOf cdh-assemblies:StructurePost5
+		vim4:hasDoubleNumber "0.6"^^xsd:double
+		vim4:characterizes cdh-assemblies:StructurePost5
 	]
 
 	// Structure Post 6 Mass
 
 	@rdfs:label "Structure Post 6 Mass Limit Constraint"
 	ci StructurePost6MassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.6"^^xsd:double
-		metrology:isQuantityOf cdh-assemblies:StructurePost6
+		vim4:hasDoubleNumber "0.6"^^xsd:double
+		vim4:characterizes cdh-assemblies:StructurePost6
 	]
 
 	// Side Panel 1 Mass
 
 	@rdfs:label "Side Panel 1 Mass Limit Constraint"
 	ci SidePanel1MassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.8"^^xsd:double
-		metrology:isQuantityOf cdh-assemblies:SidePanel1
+		vim4:hasDoubleNumber "0.8"^^xsd:double
+		vim4:characterizes cdh-assemblies:SidePanel1
 	]
 
 	// Side Panel 2 Mass
 
 	@rdfs:label "Side Panel 2 Mass Limit Constraint"
 	ci SidePanel2MassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.8"^^xsd:double
-		metrology:isQuantityOf cdh-assemblies:SidePanel2
+		vim4:hasDoubleNumber "0.8"^^xsd:double
+		vim4:characterizes cdh-assemblies:SidePanel2
 	]
 
 	// Side Panel 3 Mass
 
 	@rdfs:label "Side Panel 3 Mass Limit Constraint"
 	ci SidePanel3MassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.8"^^xsd:double
-		metrology:isQuantityOf cdh-assemblies:SidePanel3
+		vim4:hasDoubleNumber "0.8"^^xsd:double
+		vim4:characterizes cdh-assemblies:SidePanel3
 	]
 
 	// Side Panel 4 Mass
 
 	@rdfs:label "Side Panel 4 Mass Limit Constraint"
 	ci SidePanel4MassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.8"^^xsd:double
-		metrology:isQuantityOf cdh-assemblies:SidePanel4
+		vim4:hasDoubleNumber "0.8"^^xsd:double
+		vim4:characterizes cdh-assemblies:SidePanel4
 	]
 
 	// Side Panel 5 Mass
 
 	@rdfs:label "Side Panel 5 Mass Limit Constraint"
 	ci SidePanel5MassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.8"^^xsd:double
-		metrology:isQuantityOf cdh-assemblies:SidePanel5
+		vim4:hasDoubleNumber "0.8"^^xsd:double
+		vim4:characterizes cdh-assemblies:SidePanel5
 	]
 
 	// Side Panel 6 Mass
 
 	@rdfs:label "Side Panel 6 Mass Limit Constraint"
 	ci SidePanel6MassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.8"^^xsd:double
-		metrology:isQuantityOf cdh-assemblies:SidePanel6
+		vim4:hasDoubleNumber "0.8"^^xsd:double
+		vim4:characterizes cdh-assemblies:SidePanel6
 	]
 
 	// Base Plate Module Mass
 
 	@rdfs:label "Base Plate Module Mass Limit Constraint"
 	ci BasePlateModuleMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.6"^^xsd:double
-		metrology:isQuantityOf cdh-assemblies:BasePlateModule
+		vim4:hasDoubleNumber "0.6"^^xsd:double
+		vim4:characterizes cdh-assemblies:BasePlateModule
 	]
 
 	// Base Plate Mass
 
 	@rdfs:label "Base Plate Mass Limit Constraint"
 	ci BasePlateMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "1.32"^^xsd:double
-		metrology:isQuantityOf cdh-assemblies:BasePlate
+		vim4:hasDoubleNumber "1.32"^^xsd:double
+		vim4:characterizes cdh-assemblies:BasePlate
 	]
 
 	// Avionics Stack Section Mass
 
 	@rdfs:label "Avionics Stack Section Mass Limit Constraint"
 	ci AvionicsStackSectionMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.6"^^xsd:double
-		metrology:isQuantityOf cdh-assemblies:AvionicsStackSection
+		vim4:hasDoubleNumber "0.6"^^xsd:double
+		vim4:characterizes cdh-assemblies:AvionicsStackSection
 	]
 
 	// Primary Flight Computer Unit Mass
 
 	@rdfs:label "Primary Flight Computer Unit Mass Limit Constraint"
 	ci PrimaryFlightComputerUnitMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "2.35"^^xsd:double
-		metrology:isQuantityOf cdh-assemblies:PrimaryFlightComputerUnit
+		vim4:hasDoubleNumber "2.35"^^xsd:double
+		vim4:characterizes cdh-assemblies:PrimaryFlightComputerUnit
 	]
 
 	// Launch Vehicle Interface Module Mass
 
 	@rdfs:label "Launch Vehicle Interface Module Mass Limit Constraint"
 	ci LaunchVehicleInterfaceModuleMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.6"^^xsd:double
-		metrology:isQuantityOf cdh-assemblies:LaunchVehicleInterfaceModule
+		vim4:hasDoubleNumber "0.6"^^xsd:double
+		vim4:characterizes cdh-assemblies:LaunchVehicleInterfaceModule
 	]
 
 	// Launch Vehicle Adapter Mass
 
 	@rdfs:label "Launch Vehicle Adapter Mass Limit Constraint"
 	ci LaunchVehicleAdapterMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "5.0"^^xsd:double
-		metrology:isQuantityOf cdh-assemblies:LaunchVehicleAdapter
+		vim4:hasDoubleNumber "5.0"^^xsd:double
+		vim4:characterizes cdh-assemblies:LaunchVehicleAdapter
 	]
 
 	// Separation System Mass
 
 	@rdfs:label "Separation System Mass Limit Constraint"
 	ci SeparationSystemMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "3.0"^^xsd:double
-		metrology:isQuantityOf cdh-assemblies:SeparationSystem
+		vim4:hasDoubleNumber "3.0"^^xsd:double
+		vim4:characterizes cdh-assemblies:SeparationSystem
 	]
 
 	// Propellant Tank Mounting Panel Mass
 
 	@rdfs:label "Propellant Tank Mounting Panel Mass Limit Constraint"
 	ci PropellantTankMountingPanelMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "2.7"^^xsd:double
-		metrology:isQuantityOf cdh-assemblies:PropellantTankMountingPanel
+		vim4:hasDoubleNumber "2.7"^^xsd:double
+		vim4:characterizes cdh-assemblies:PropellantTankMountingPanel
 	]
 
 	// Pressurant Tank Mounting Panel Mass
 
 	@rdfs:label "Pressurant Tank Mounting Panel Mass Limit Constraint"
 	ci PressurantTankMountingPanelMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "2.7"^^xsd:double
-		metrology:isQuantityOf cdh-assemblies:PressurantTankMountingPanel
+		vim4:hasDoubleNumber "2.7"^^xsd:double
+		vim4:characterizes cdh-assemblies:PressurantTankMountingPanel
 	]
 
 	// Payload Structural Interface Mass
 
 	@rdfs:label "Payload Structural Interface Mass Limit Constraint"
 	ci PayloadStructuralInterfaceMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "3.5"^^xsd:double
-		metrology:isQuantityOf cdh-assemblies:PayloadStructuralInterface
+		vim4:hasDoubleNumber "3.5"^^xsd:double
+		vim4:characterizes cdh-assemblies:PayloadStructuralInterface
 	]
 
 	// Top Panel Module Mass
 
 	@rdfs:label "Top Panel Module Mass Limit Constraint"
 	ci TopPanelModuleMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.6"^^xsd:double
-		metrology:isQuantityOf cdh-assemblies:TopPanelModule
+		vim4:hasDoubleNumber "0.6"^^xsd:double
+		vim4:characterizes cdh-assemblies:TopPanelModule
 	]
 
 	// Top Panel Mass
 
 	@rdfs:label "Top Panel Mass Limit Constraint"
 	ci TopPanelMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "2.7"^^xsd:double
-		metrology:isQuantityOf cdh-assemblies:TopPanel
+		vim4:hasDoubleNumber "2.7"^^xsd:double
+		vim4:characterizes cdh-assemblies:TopPanel
 	]
 
 }

--- a/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/workpackages/06/systems/spc/masses.oml
+++ b/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/workpackages/06/systems/spc/masses.oml
@@ -7,7 +7,7 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 
 	uses <http://www.w3.org/2000/01/rdf-schema#> as rdfs
 
-	uses <http://iupac.org/metrology#> as metrology
+	uses <http://bipm.org/jcgm/vim4#> as vim4
 
 	uses <http://opencaesar.io/examples/firesat/disciplines/fse/fse#> as fse
 
@@ -17,8 +17,8 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 
 	@rdfs:label "Spacecraft System Segment Mass Limit Constraint"
 	ci SpacecraftSystemSegmentMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "0.6"^^xsd:double
-		metrology:isQuantityOf spc-assemblies:SpacecraftSystemSegment
+		vim4:hasDoubleNumber "0.6"^^xsd:double
+		vim4:characterizes spc-assemblies:SpacecraftSystemSegment
 	]
 
 }

--- a/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/workpackages/06/systems/spc/subsystems/ang/masses.oml
+++ b/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/workpackages/06/systems/spc/subsystems/ang/masses.oml
@@ -7,7 +7,7 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 
 	uses <http://www.w3.org/2000/01/rdf-schema#> as rdfs 
 
-	uses <http://iupac.org/metrology#> as metrology
+	uses <http://bipm.org/jcgm/vim4#> as vim4
 
 	uses <http://opencaesar.io/examples/firesat/disciplines/fse/fse#> as fse
 
@@ -17,8 +17,8 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 
 	@rdfs:label "ADCS and GNC Mass Limit Constraint"
 	ci ADCSAndGNCMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "9.74"^^xsd:double
-		metrology:isQuantityOf ang:ADCSAndGNC
+		vim4:hasDoubleNumber "9.74"^^xsd:double
+		vim4:characterizes ang:ADCSAndGNC
 	]
 
 }

--- a/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/workpackages/06/systems/spc/subsystems/cdh/masses.oml
+++ b/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/workpackages/06/systems/spc/subsystems/cdh/masses.oml
@@ -7,7 +7,7 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 
 	uses <http://www.w3.org/2000/01/rdf-schema#> as rdfs 
 
-	uses <http://iupac.org/metrology#> as metrology
+	uses <http://bipm.org/jcgm/vim4#> as vim4
 
 	uses <http://opencaesar.io/examples/firesat/disciplines/fse/fse#> as fse
 
@@ -17,8 +17,8 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 
 	@rdfs:label "Command and Data Handling Mass Limit Constraint"
 	ci CommandAndDataHandlingassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "38.07"^^xsd:double
-		metrology:isQuantityOf cdh:CommandAndDataHandling
+		vim4:hasDoubleNumber "38.07"^^xsd:double
+		vim4:characterizes cdh:CommandAndDataHandling
 	]
 
 }

--- a/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/workpackages/06/systems/spc/subsystems/cmn/masses.oml
+++ b/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/workpackages/06/systems/spc/subsystems/cmn/masses.oml
@@ -7,7 +7,7 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 
 	uses <http://www.w3.org/2000/01/rdf-schema#> as rdfs 
 
-	uses <http://iupac.org/metrology#> as metrology
+	uses <http://bipm.org/jcgm/vim4#> as vim4
 
 	uses <http://opencaesar.io/examples/firesat/disciplines/fse/fse#> as fse
 
@@ -17,8 +17,8 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 
 	@rdfs:label "Communications Mass Limit Constraint"
 	ci CommunicationsMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "3.26"^^xsd:double
-		metrology:isQuantityOf cmn:Communications
+		vim4:hasDoubleNumber "3.26"^^xsd:double
+		vim4:characterizes cmn:Communications
 	]
 
 }

--- a/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/workpackages/06/systems/spc/subsystems/eps/masses.oml
+++ b/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/workpackages/06/systems/spc/subsystems/eps/masses.oml
@@ -7,7 +7,7 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 
 	uses <http://www.w3.org/2000/01/rdf-schema#> as rdfs 
 
-	uses <http://iupac.org/metrology#> as metrology
+	uses <http://bipm.org/jcgm/vim4#> as vim4
 
 	uses <http://opencaesar.io/examples/firesat/disciplines/fse/fse#> as fse
 
@@ -17,8 +17,8 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 
 	@rdfs:label "Electric Power System Mass Limit Constraint"
 	ci EPSMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "9.31"^^xsd:double
-		metrology:isQuantityOf eps:ElectricPowerSystem
+		vim4:hasDoubleNumber "9.31"^^xsd:double
+		vim4:characterizes eps:ElectricPowerSystem
 	]
 
 }

--- a/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/workpackages/06/systems/spc/subsystems/prp/masses.oml
+++ b/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/workpackages/06/systems/spc/subsystems/prp/masses.oml
@@ -7,7 +7,7 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 
 	uses <http://www.w3.org/2000/01/rdf-schema#> as rdfs 
 
-	uses <http://iupac.org/metrology#> as metrology
+	uses <http://bipm.org/jcgm/vim4#> as vim4
 
 	uses <http://opencaesar.io/examples/firesat/disciplines/fse/fse#> as fse
 
@@ -17,8 +17,8 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 
 	@rdfs:label "Propulsion Mass Limit Constraint"
 	ci PropulsionMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "44.14"^^xsd:double
-		metrology:isQuantityOf prp:Propulsion
+		vim4:hasDoubleNumber "44.14"^^xsd:double
+		vim4:characterizes prp:Propulsion
 	]
 
 }

--- a/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/workpackages/06/systems/spc/subsystems/sam/masses.oml
+++ b/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/workpackages/06/systems/spc/subsystems/sam/masses.oml
@@ -7,7 +7,7 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 
 	uses <http://www.w3.org/2000/01/rdf-schema#> as rdfs 
 
-	uses <http://iupac.org/metrology#> as metrology
+	uses <http://bipm.org/jcgm/vim4#> as vim4
 
 	uses <http://opencaesar.io/examples/firesat/disciplines/fse/fse#> as fse
 
@@ -17,8 +17,8 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 
 	@rdfs:label "Structures and Mechanisms Mass Limit Constraint"
 	ci StructuresAndMechanismsMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "5.0"^^xsd:double
-		metrology:isQuantityOf sam:StructuresAndMechanisms
+		vim4:hasDoubleNumber "5.0"^^xsd:double
+		vim4:characterizes sam:StructuresAndMechanisms
 	]
 
 }

--- a/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/workpackages/06/systems/spc/subsystems/thc/masses.oml
+++ b/src/oml/opencaesar.io/examples/firesat/programs/earth-science/projects/firesat/workpackages/06/systems/spc/subsystems/thc/masses.oml
@@ -7,7 +7,7 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 
 	uses <http://www.w3.org/2000/01/rdf-schema#> as rdfs 
 
-	uses <http://iupac.org/metrology#> as metrology
+	uses <http://bipm.org/jcgm/vim4#> as vim4
 
 	uses <http://opencaesar.io/examples/firesat/disciplines/fse/fse#> as fse
 
@@ -17,8 +17,8 @@ description <http://opencaesar.io/examples/firesat/programs/earth-science/projec
 
 	@rdfs:label "Thermal Control Mass Limit Constraint"
 	ci ThermalControlMassLimitConstraint : fse:MassLimitConstraint [
-		metrology:hasDoubleNumber "3.9"^^xsd:double
-		metrology:isQuantityOf thc:ThermalControl
+		vim4:hasDoubleNumber "3.9"^^xsd:double
+		vim4:characterizes thc:ThermalControl
 	]
 
 }


### PR DESCRIPTION
There is a strange problem: 

```
.\gradlew clean build
> Task :owlReason FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':owlReason'.
> Adding type to a pruned node SensorMassLimitConstraint FunNot(FunAll(http://bipm.org/jcgm/vim4#unit,FunNot(FunValue(http://iso.org/iso-80000-4.1#kilogram))))
```

The stack trace shows:

```
Caused by: openllet.core.exceptions.InternalReasonerException: Adding type to a pruned node SensorMassLimitConstraint FunNot(FunAll(http://bipm.org/jcgm/vim4#instantiates,FunNot(FunValue(http://iso.org/iso-80000-4.1#mass))))
        at openllet.core.boxes.abox.Individual.addType(Individual.java:276)
        at openllet.core.boxes.abox.Individual.addType(Individual.java:266)
        at openllet.core.tableau.completion.CompletionStrategy.addType(CompletionStrategy.java:420)
        at openllet.core.rules.ContinuousRulesStrategy.addType(ContinuousRulesStrategy.java:96)
        at openllet.core.tableau.completion.rule.UnfoldingRule.applyUnfoldingRule(UnfoldingRule.java:99)
        at openllet.core.tableau.completion.rule.UnfoldingRule.apply(UnfoldingRule.java:60)
        at openllet.core.tableau.completion.rule.AbstractTableauRule.apply(AbstractTableauRule.java:106)
        at openllet.core.rules.ContinuousRulesStrategy.complete(ContinuousRulesStrategy.java:251)
        at openllet.core.boxes.abox.ABoxImpl.lambda$isConsistent$12(ABoxImpl.java:1417)
        at openllet.core.utils.Timers.execute(Timers.java:118)
        at openllet.core.boxes.abox.ABoxImpl.isConsistent(ABoxImpl.java:1417)
        at openllet.core.boxes.abox.ABoxImpl.isConsistent(ABoxImpl.java:1269)
        at openllet.core.KnowledgeBaseImpl.consistency(KnowledgeBaseImpl.java:1802)
        at openllet.core.KnowledgeBaseImpl.isConsistent(KnowledgeBaseImpl.java:1877)
        at openllet.core.KnowledgeBaseImplFullSync.isConsistent(KnowledgeBaseImplFullSync.java:403)
        at openllet.owlapi.PelletReasoner.isConsistent(PelletReasoner.java:1032)
        at io.opencaesar.owl.reason.OwlReasonApp.checkConsistency(OwlReasonApp.java:331)
        at io.opencaesar.owl.reason.OwlReasonApp.check(OwlReasonApp.java:298)
        at io.opencaesar.owl.reason.OwlReasonApp.run(OwlReasonApp.java:257)
        at io.opencaesar.owl.reason.OwlReasonApp.main(OwlReasonApp.java:228)
```